### PR TITLE
Conduct discussions in pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,15 @@ And then create draft proposals ([draft 1](./draft.md), [draft 2](./draft2.md)).
 
 I have not started to write code yet.
 
-# discussion process
+# contributing
 
-All discussion should yield updates to the design documents.
-Therefore, rather than opening discussions as issues, they should be submitted as PRs which include
+Discussions and questions are welcome in the issues board.
+Decisions are not final until a PR updating the documents has been merged!
 
- 1. An opening summary of the topic under discussion
- 2. An opinionated patch to the documents
-
-Discussion will then take place in the PR, and the patch will be modified to reflect the final decisions.
-
-If the author does not have a strong opinion on what the final decision should be, the patch should at least reflect the potential updates to the documents.
+PRs should summarize the decision sufficiently so that you do not need to read the issues board unless you want to.
+This includes summarizing choices which were discarded, and for what reasons.
+Be thorough!
+If something is not in the documentation, it has not been decided.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ And then create draft proposals ([draft 1](./draft.md), [draft 2](./draft2.md)).
 
 I have not started to write code yet.
 
+# discussion process
+
+All discussion should yield updates to the design documents.
+Therefore, rather than opening discussions as issues, they should be submitted as PRs which include
+
+ 1. An opening summary of the topic under discussion
+ 2. An opinionated patch to the documents
+
+Discussion will then take place in the PR, and the patch will be modified to reflect the final decisions.
+
+If the author does not have a strong opinion on what the final decision should be, the patch should at least reflect the potential updates to the documents.
+
 # License
 
 MI


### PR DESCRIPTION
It's important that the repo's documents reflect all of the decisions and discoveries made by ADC. The issue board is bad at indexing the latest consensus.

I propose we use PRs to conduct discussions. Each PR would include an opinionated patch to the docs, and a summary of the topic to discuss. Discussion can then take place on the PR. The patch will be updated to reflect the decisions, and merged (or closed) when consensus is reached.
