### PR TITLE
document behavior of private-stream under replay and middleman attacks

### DIFF
--- a/prior-art.md
+++ b/prior-art.md
@@ -17,7 +17,7 @@ I was considering putting authentication inside of this protocol but I am now re
 Alice and Bob meet in a dark alleyway
 
 Alice & Bob (simultaniously) passes each other a secret note, also with random number written on outside.
-i
+
 ``` js
 var local_kx = createKeyExchange()
 var local_nonce = secureRandom()
@@ -32,7 +32,7 @@ var remote_kx, remote_nonce = connection.read()
 ```
 
 Alice and Bob now combine their secret, with the secret they received and the random numbers,
-to communicate with each other.
+these are used to create the ciphers.
 
 ``` js
 var shared_key = local_kx.computeSecret(remote_kx)
@@ -64,14 +64,14 @@ Alice and Bob create key exchanges and nonces and send them to Mallory. Mallory 
 establishing private connections to each of them. When Alice or Bob send encrypted data, they send it to Mallory,
 who decrypts it, reads and possibly alters the plaintext, and reencrypts it the other party.
 Thus Mallory can read and alter all the data sent by Alice or Bob,
-who do not have anyway to know they are the victums of a middleman.
+who do not have anyway to know they are the victims of a middleman.
 
 * middleman can read and alter plaintext arbitarily.
 
 ### Replay attack on a private-stream.
 
-Rodger eaves drops on Alice and Bob's conversation, and then later
-connects to Bob and resends what Alice sent a previous time.
+Rodger eavesdrops on Alice and Bob's conversation, and then later
+connects to Bob and resends what Alice sent the previous time.
 
 Rodger sends the first packet Alice sent,
 which was the key exchange and nonce,
@@ -98,6 +98,8 @@ it would at least fail to decrypt those packets safely, without passing garbage 
 ### Key Compromise on private-stream
 
 not applicable, because private-stream does not verify remote identity.
+
+### Conclusion on private-stream
 
 ### Further Reading
 

--- a/prior-art.md
+++ b/prior-art.md
@@ -8,7 +8,7 @@ so it may not be necessary to send the key inside the connection.
 
 ## private-stream
 
-[private-stream](https://github.com/dominictarr/private-stream) is a very simple private protocol that I wrote. It provides encryption, but not authentication. That is, you cannot be sure exactly who you are talking to, but you may be sure that no one else is listening. It is a symmetrical protocol, in that client and server handshake are identical. Each peer sends a Diffie Helman public key + an Initialization Vector (8 byte random number). The DH keys are combined to produce a shared key, and a cipher streams (salsa20) are constructed using the shared key and the two ivs so that each channel (A->B, and B->A) have the same key but different IVs (which is sufficient for security)
+[private-stream](https://github.com/dominictarr/private-stream) is a very simple private protocol that I wrote. It provides encryption, but not authentication. That is, you cannot be sure exactly who you are talking to, but you may be sure that no one else is listening. It is a symmetrical protocol, in that client and server handshake are identical. Each peer sends a Diffie Helman public key + an Initialization Vector (8 byte random number). The DH keys are combined to produce a shared key, and a cipher streams (salsa20) are constructed using the shared key and the two ivs so that each channel (A->B, and B->A) have the same key but different IVs (which is sufficient for privacy)
 
 I was considering putting authentication inside of this protocol but I am now re-evaluating that.
 


### PR DESCRIPTION
This PR greatly improves the detail which private-stream is documented, especially it's behavior when attacked.

I used pseudocode for the correct operation, but just used an AliceBob story for the attacks. Since this is sufficient to demonstrate why not to use this protocol, I don't think it's necessary to use more detail here.

TODO: add descriptions at this level of detail for the other protocols.
