### PR TITLE
rename to secret-handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 
-# secure-channel
+# secret-handshake
 
-This is a project to design a secure-channel (encrypted duplex connection)
+This is a project to design a secret handshake -
+a protocol to mutually authenticate two parties,
+and derive a shared secret.
+
+This shared secret could then be used to securely communicate
+via an encrytped and authenticated stream, though that has additional
+considerations which will not be discussed here.
 
 # design process
 

--- a/draft.md
+++ b/draft.md
@@ -1,6 +1,6 @@
 # Protocol Draft 1
 
-Alice wants to connect to Bob and communicate privately. Also, we want to realize _all_ the [desireable properties for a secure channel](./properties.md). This protocol is inspired by [curvecp](./prior-art.md#curvecp) but avoid the [problems with curvecp](./prior-art.md#conclusion)
+Alice wants to connect to Bob and communicate privately. Also, we want to realize _all_ the [desireable properties for a secret handshake](./properties.md). This protocol is inspired by [curvecp](./prior-art.md#curvecp) but avoid the [problems with curvecp](./prior-art.md#conclusion)
 
 This also differs from curvecp in that it is intended to function as a layer on top of a reliable tcp-like connection, instead of a UDP protocol. Although curvecp does solve some tcp problems by using udp, for my usecase I require the ability to encrypt connections over an arbitrary reliable duplex stream (in particular over tcp, but potentially over other protocols too)
 

--- a/draft2.md
+++ b/draft2.md
@@ -80,6 +80,6 @@ Now Alice and Bob are mutually authenticated! Bob knows he's talking to Alice, a
 
 the rest of the session is encrypted with Aaron/Barbara. Even the existence of these keys is a secret from both an eavesdropper or a man in the middle!
 
-This design realizes _all_ the [desirable secure channel properties](./properties.md)
+This design realizes _all_ the [desirable secret handshake properties](./properties.md)
 
 

--- a/properties.md
+++ b/properties.md
@@ -1,7 +1,7 @@
 
-# Desireable Properties for a Secure Channel
+# Desireable Properties for a Secret Handshake
 
-here is a list of properties that I think are desirable in a p2p secure channel. It is assumed that peers already know the pubkeys of a server. It may not be possible to support _all_ of these properties in one protocol.
+here is a list of properties that I think are desirable in a p2p secret handshake. It is assumed that peers already know the pubkeys of a server. It may not be possible to support _all_ of these properties in one protocol.
 
 1. content is forward secure
 2. server verifies client identity


### PR DESCRIPTION
The goal of this module would be clearer if it was renamed to secret-handshake.
All the investigation so far is about how the handshake works, and once that is complete encryption of the rest of the session (which tls calls "bulk encryption") is relatively simpler.
Properties of bulk encryption can be delt with separately, and then if necessary, the combination of a secret-handshake + bulk encryption can be discussed, but those are separate problems, and can be in separate projects.
